### PR TITLE
chore: renovate 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,21 @@
+{
+	"extends": ["config:base"],
+	"separateMajorMinor": true,
+	"timezone": "Europe/London",
+	"schedule": ["after 7am and before 9am every weekday"],
+	"labels": ["dependencies"],
+	"packageRules": [
+		{
+			"matchPackagePatterns": ["*"],
+			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+			"groupName": "all non-major dependency updates",
+			"groupSlug": "all-minor-patch",
+			"automerge": true,
+			"automergeStrategy": "squash",
+			"platformAutomerge": true
+		}
+	],
+	"vulnerabilityAlerts": {
+		"labels": ["security"]
+	}
+}


### PR DESCRIPTION
### Overview

Use Renovate instead of Depadabot for dependancy updates.

Reasons:
- Better pnpm support (dependabot doesn't support pnpm security updates yet)
- Group minor updates (dependabot doesn't support update grouping (why?!))
- Better visibility with Issue tracking to see what Renovate is planning

### Type of change

- [ ] ✨ **Feature** - a new component or behaviour has been added
- [ ] 🐛 **Fix** - fixing a known issue within the codebase
- [x] ♻️ **Chore** - maintenance task where behaviour and implementation haven't changed
- [ ] 📝 **Docs** - updating any README or markdown files

### Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have set the PR title to conventional commit format.
- [ ] I have built any changed GitHub Actions.
