### PR TITLE
chore: Playwright shared config across apps

### DIFF
--- a/apps/app/playwright.config.ts
+++ b/apps/app/playwright.config.ts
@@ -1,29 +1,12 @@
-import { defineConfig, devices } from '@playwright/test';
-
-export default defineConfig({
-	testDir: './tests',
-	fullyParallel: true,
-	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
-	workers: process.env.CI ? 1 : undefined,
-	reporter: 'html',
+import config from '../../playwright.config';
+export default {
+	...config,
 	use: {
+		...config.use,
 		baseURL: 'http://localhost:4174',
-		trace: 'on-first-retry',
 	},
-	projects: [
-		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] },
-		},
-		{
-			name: 'Mobile Safari',
-			use: { ...devices['iPhone 12'] },
-		},
-	],
 	webServer: {
-		command: 'pnpm preview',
+		...config.webServer,
 		url: 'http://localhost:4174',
-		reuseExistingServer: !process.env.CI,
 	},
-});
+};

--- a/apps/marketing/playwright.config.ts
+++ b/apps/marketing/playwright.config.ts
@@ -1,29 +1,12 @@
-import { defineConfig, devices } from '@playwright/test';
-
-export default defineConfig({
-	testDir: './tests',
-	fullyParallel: true,
-	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
-	workers: process.env.CI ? 1 : undefined,
-	reporter: 'html',
+import config from '../../playwright.config';
+export default {
+	...config,
 	use: {
+		...config.use,
 		baseURL: 'http://localhost:4173',
-		trace: 'on-first-retry',
 	},
-	projects: [
-		{
-			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] },
-		},
-		{
-			name: 'Mobile Safari',
-			use: { ...devices['iPhone 12'] },
-		},
-	],
 	webServer: {
-		command: 'pnpm preview',
+		...config.webServer,
 		url: 'http://localhost:4173',
-		reuseExistingServer: !process.env.CI,
 	},
-});
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
 	workers: process.env.CI ? 1 : undefined,
 	reporter: 'html',
 	use: {
-		baseURL: 'http://localhost:4173',
 		trace: 'on-first-retry',
 	},
 	projects: [
@@ -23,7 +22,6 @@ export default defineConfig({
 	],
 	webServer: {
 		command: 'pnpm preview',
-		url: 'http://localhost:4173',
 		reuseExistingServer: !process.env.CI,
 	},
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+	testDir: './tests',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: 'html',
+	use: {
+		baseURL: 'http://localhost:4173',
+		trace: 'on-first-retry',
+	},
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] },
+		},
+		{
+			name: 'Mobile Safari',
+			use: { ...devices['iPhone 12'] },
+		},
+	],
+	webServer: {
+		command: 'pnpm preview',
+		url: 'http://localhost:4173',
+		reuseExistingServer: !process.env.CI,
+	},
+});


### PR DESCRIPTION
### Overview

Enable a single shared playwright config across apps but change the preview port.

### Type of change

- [ ] ✨ **Feature** - a new component or behaviour has been added
- [ ] 🐛 **Fix** - fixing a known issue within the codebase
- [x] ♻️ **Chore** - maintenance task where behaviour and implementation haven't changed
- [ ] 📝 **Docs** - updating any README or markdown files

### Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have set the PR title to conventional commit format.
- [ ] I have built any changed GitHub Actions.

